### PR TITLE
allow aws provider upgrade upto 4.12, maintaining backwards compatibi…

### DIFF
--- a/modules/aws_ecs_ec2/main.tf
+++ b/modules/aws_ecs_ec2/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.12.0"
+      version = ">= 3.50, <= 4.12.0"
     }
   }
 }


### PR DESCRIPTION
support lower versions while we're working towards upgrade