### PR TITLE
Remove explicit aws_autoscaling_policy adjustment_type

### DIFF
--- a/modules/aws_ecs_ec2/main.tf
+++ b/modules/aws_ecs_ec2/main.tf
@@ -107,14 +107,13 @@ resource "aws_autoscaling_group" "this" {
     value               = "${var.deployment_name}-ec2-instance"
     propagate_at_launch = true
   }
-  
+
 }
 
 # Attach an autoscaling policy to the spot cluster to target 70% MemoryReservation on the ECS cluster.
 resource "aws_autoscaling_policy" "this" {
   name                   = "${var.deployment_name}-ecs-scale-policy"
   policy_type            = "TargetTrackingScaling"
-  adjustment_type        = "ChangeInCapacity"
   autoscaling_group_name = aws_autoscaling_group.this.name
 
   target_tracking_configuration {


### PR DESCRIPTION
Seeing a redundant diff on every terraform plan, so hoping to avoid that.
<img width="447" alt="image" src="https://user-images.githubusercontent.com/8420659/174814991-a9f5b6c5-1eac-4959-b893-7822095941a3.png">
