### PR TITLE
copy new stuff from aws_ecs to existing aws_ecs_ecs

### DIFF
--- a/modules/aws_ecs_ec2/README.md
+++ b/modules/aws_ecs_ec2/README.md
@@ -18,6 +18,7 @@ module "retool" {
     ]
     ssh_key_name = "<your-key-pair>"
     ecs_retool_image = "<desired-retool-version>"
+    workflows_enabled = true
 
     # Additional configuration
     ...
@@ -27,6 +28,7 @@ module "retool" {
 2. Run `terraform init` to install all requirements for the module.
 
 3. Replace `ecs_retool_image` with your desired [Retool Version](https://docs.retool.com/docs/updating-retool-on-premise#retool-release-versions). The format should be `tryretool/backend:X.Y.Z`, where `X.Y.Z` is your desired version number.
+Version 2.111 or greater is needed for Workflows (2.117 or later strongly recommended for performance improvements).
 
 4. Ensure that the default security settings in `security.tf` matches your specifications. If you need to tighten down access, pass in custom ingress and egress rules into `ec2_egress_rules`, `ec2_ingress_rules`, `alb_egress_rules`, and `alb_ingress_rules`.
 
@@ -49,7 +51,8 @@ To configure the EC instance size, set the `instance_type` input variable (e.g. 
 To configure the RDS instance class, set the `instance_class` input variable (e.g. `db.m6g.large`).
 
 ## Advanced Configuration
-
+**Bring your own Temporal Cluster**
+To configure your own Temporal cluster, set the `use_existing_temporal_cluster` to `true` and configure your Temporal Cluster's Frontend service endpoint (and TLS if needed) using `temporal_cluster_config`. If configuring mTLS, we expect the cert and key values to be base64-encoded strings.
 ### Security Groups
 
 To customize the ingress and egress rules on the security groups, you can override specific input variable defaults.

--- a/modules/aws_ecs_ec2/locals.tf
+++ b/modules/aws_ecs_ec2/locals.tf
@@ -1,6 +1,7 @@
 locals {
   environment_variables = concat(
     var.additional_env_vars, # add additional environment variables
+    local.temporal_mtls_config,
     [
       {
         name  = "NODE_ENV"
@@ -45,7 +46,43 @@ locals {
       {
         "name" : "LICENSE_KEY",
         "value" : var.retool_license_key
+      },
+      # Workflows-specific
+      {
+        "name" : "WORKFLOW_BACKEND_HOST",
+        "value" : "http://workflow-backend.retoolsvc:3000"
+      },
+      {
+        "name" : "WORKFLOW_TEMPORAL_CLUSTER_NAMESPACE",
+        "value" : var.temporal_cluster_config.namespace
+      },
+      {
+        "name" : "WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_HOST",
+        "value" : var.temporal_cluster_config.host
+      },
+      {
+        "name" : "WORKFLOW_TEMPORAL_CLUSTER_FRONTEND_PORT",
+        "value" : var.temporal_cluster_config.port
+      },
+      {
+        "name" : "WORKFLOW_TEMPORAL_TLS_ENABLED",
+        "value" : tostring(var.temporal_cluster_config.tls_enabled)
       }
     ]
+  )
+
+  temporal_mtls_config = (
+    var.temporal_cluster_config.tls_enabled && var.temporal_cluster_config.tls_crt != null && var.temporal_cluster_config.tls_key != null ?
+    [
+      {
+        "name" : "WORKFLOW_TEMPORAL_TLS_CRT",
+        "value" : var.temporal_cluster_config.tls_crt
+      },
+      {
+        "name" : "WORKFLOW_TEMPORAL_TLS_KEY",
+        "value" : var.temporal_cluster_config.tls_key
+      }
+    ] :
+    []
   )
 }

--- a/modules/aws_ecs_ec2/security.tf
+++ b/modules/aws_ecs_ec2/security.tf
@@ -28,6 +28,20 @@ resource "aws_security_group" "rds" {
   }
 }
 
+resource "aws_security_group" "temporal_aurora" {
+  count       = var.workflows_enabled ? 1 : 0
+  name        = "${var.deployment_name}-temporal-rds-security-group"
+  description = "Retool database security group"
+
+  ingress {
+    description = "Retool Temporal ECS Postgres Inbound"
+    from_port   = "5432"
+    to_port     = "5432"
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 resource "aws_security_group" "alb" {
   name        = "${var.deployment_name}-alb-security-group"
   description = "Retool load balancer security group"

--- a/modules/aws_ecs_ec2/temporal/locals.tf
+++ b/modules/aws_ecs_ec2/temporal/locals.tf
@@ -1,0 +1,51 @@
+locals {
+  environment_variables = concat(
+    var.additional_env_vars, # add additional environment variables
+    [
+      {
+        "name": "LOG_LEVEL",
+        "value": "debug,info"
+      },
+      {
+        "name": "NUM_HISTORY_SHARDS",
+        "value": "128"
+      },
+      {
+        "name": "DB",
+        "value": "postgresql"
+      },
+      {
+        "name": "POSTGRES_HOST",
+        "value": module.temporal_aurora_rds.cluster_endpoint
+      },
+      {
+        "name": "POSTGRES_PORT",
+        "value": tostring(module.temporal_aurora_rds.cluster_port)
+      },
+      {
+        "name": "POSTGRES_USER",
+        "value": var.temporal_aurora_username
+      },
+      {
+        "name": "POSTGRES_PASSWORD",
+        "value": random_string.temporal_aurora_password.result
+      },
+      {
+        "name": "DBNAME",
+        "value": "temporal"
+      },
+      {
+        "name": "DBNAME_VISIBILITY",
+        "value": "temporal_visibility"
+      },
+      {
+        "name": "DYNAMIC_CONFIG_FILE_PATH",
+        "value": "/etc/temporal/ecs/dynamic_config/dynamicconfig-sql.yaml"
+      },
+      {
+        "name": "ECS_DEPLOYED",
+        "value": "true"
+      }
+    ]
+  )
+}

--- a/modules/aws_ecs_ec2/temporal/main.tf
+++ b/modules/aws_ecs_ec2/temporal/main.tf
@@ -1,0 +1,157 @@
+module "temporal_aurora_rds" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "8.0.2"
+
+  name="${var.deployment_name}-temporal-rds-instance"
+  engine            = "aurora-postgresql"
+  engine_mode       = "provisioned"
+  engine_version    = "14.5"
+  storage_encrypted = true
+
+  vpc_id               = var.vpc_id
+
+  monitoring_interval = 60
+
+  # Create DB Subnet group using var.subnet_ids
+  create_db_subnet_group = true
+  subnets = var.subnet_ids
+
+  master_username = aws_secretsmanager_secret_version.temporal_aurora_username.secret_string
+  master_password = aws_secretsmanager_secret_version.temporal_aurora_password.secret_string
+  manage_master_user_password = false
+
+  apply_immediately   = true
+  skip_final_snapshot = true
+
+  serverlessv2_scaling_configuration = {
+    min_capacity = 0.5
+    max_capacity = 10
+  }
+
+  security_group_rules = {
+    temporal_ingress = {
+      source_security_group_id = var.container_sg_id
+    }
+  }
+
+  instance_class = "db.serverless"
+  instances = {
+    one = {}
+  }
+}
+
+resource "aws_service_discovery_service" "temporal_frontend_service" { 
+  name  = "temporal"
+
+  dns_config {
+    namespace_id = var.private_dns_namespace_id
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_ecs_service" "retool_temporal" {
+
+  for_each = var.temporal_services_config
+
+  name            = "${var.deployment_name}-${each.key}"
+  cluster         = var.aws_ecs_cluster_id
+  desired_count   = 1
+  task_definition = aws_ecs_task_definition.retool_temporal[each.key].arn
+
+  # Need to explictly set this in aws_ecs_service to avoid destructive behavior: https://github.com/hashicorp/terraform-provider-aws/issues/22823
+  capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = var.launch_type == "FARGATE" ? "FARGATE" : var.aws_ecs_capacity_provider_name
+  }
+
+  dynamic "service_registries" {
+    for_each = each.key == "frontend" ? toset([1]) : toset([])
+    content {
+      registry_arn = aws_service_discovery_service.temporal_frontend_service.arn
+    }
+  }
+
+  dynamic "network_configuration" {
+    for_each = var.launch_type == "FARGATE" ? toset([1]) : toset([])
+
+    content {    
+      subnets = var.subnet_ids
+      security_groups = [
+        var.container_sg_id
+      ]
+      assign_public_ip = true
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "retool_temporal" {
+
+  for_each = var.temporal_services_config
+
+  family        = "${var.deployment_name}-${each.key}"
+  task_role_arn = aws_iam_role.task_role.arn
+  execution_role_arn = var.launch_type == "FARGATE" ? aws_iam_role.execution_role[0].arn : null
+  requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : null
+  network_mode  = var.launch_type == "FARGATE" ? "awsvpc" : "bridge"
+  cpu       = var.launch_type == "FARGATE" ? each.value["cpu"] : null
+  memory    = var.launch_type == "FARGATE" ? each.value["memory"] : null
+  container_definitions = jsonencode(
+    [
+      {
+        name      = "${var.deployment_name}-${each.key}"
+        essential = true
+        image     = var.temporal_image
+        cpu       = var.launch_type == "EC2" ? each.value["cpu"] : null
+        memory    = var.launch_type == "EC2" ? each.value["memory"] : null
+
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = var.aws_cloudwatch_log_group_id
+            awslogs-region        = var.aws_region
+            awslogs-stream-prefix = "SERVICE_RETOOL_TEMPORAL"
+          }
+        }
+
+        portMappings = [
+          {
+            containerPort = each.value["request_port"]
+            hostPort      = each.value["request_port"]
+            protocol      = "tcp"
+          },
+          {
+            containerPort = each.value["membership_port"]
+            hostPort      = each.value["membership_port"]
+            protocol      = "tcp"
+          }
+        ]
+
+        environment = concat(
+          local.environment_variables,
+          [
+            {
+              "name"  = "SERVICES"
+              "value" = each.key
+            },
+          ],
+          each.key != "frontend" ? [ {
+              "name": "PUBLIC_FRONTEND_ADDRESS",
+              "value": "${var.temporal_cluster_config.host}:${var.temporal_cluster_config.port}"
+            }
+          ] : []
+        )
+      }
+    ]
+  )
+}

--- a/modules/aws_ecs_ec2/temporal/roles.tf
+++ b/modules/aws_ecs_ec2/temporal/roles.tf
@@ -1,0 +1,77 @@
+data "aws_iam_policy_document" "task_role_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_role" {
+  name               = "${var.deployment_name}-task-role"
+  assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
+  path               = "/"
+}
+
+data "aws_iam_policy_document" "service_role_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "service_role_policy" {
+  statement {
+    actions = [
+      "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+      "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:Describe*",
+      "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+      "elasticloadbalancing:RegisterTargets",
+      "ec2:Describe*",
+      "ec2:AuthorizeSecurityGroupIngress"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "service_role" {
+  name               = "${var.deployment_name}-service-role"
+  assume_role_policy = data.aws_iam_policy_document.service_role_assume_policy.json
+  path               = "/"
+
+  inline_policy {
+    name   = "${var.deployment_name}-service-policy"
+    policy = data.aws_iam_policy_document.service_role_policy.json
+  }
+}
+
+# Execution Role for Fargate
+data "aws_iam_policy_document" "execution_role_assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution_role" {
+  count              = var.launch_type == "FARGATE" ? 1 : 0
+  name               = "${var.deployment_name}-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.execution_role_assume_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "execution_role" {
+  count      = var.launch_type == "FARGATE" ? 1 : 0
+  role       = aws_iam_role.execution_role[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/modules/aws_ecs_ec2/temporal/secrets.tf
+++ b/modules/aws_ecs_ec2/temporal/secrets.tf
@@ -1,0 +1,27 @@
+
+resource "random_string" "temporal_aurora_password" {
+  length  = var.secret_length
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "temporal_aurora_password" {
+  name        = "${var.deployment_name}-temporal-rds-password"
+  description = "This is the password for the Retool Temporal RDS instance"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "temporal_aurora_password" {
+  secret_id     = aws_secretsmanager_secret.temporal_aurora_password.id
+  secret_string = random_string.temporal_aurora_password.result
+}
+
+resource "aws_secretsmanager_secret" "temporal_aurora_username" {
+  name        = "${var.deployment_name}-temporal-rds-username"
+  description = "This is the username for the Retool Temporal RDS instance"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "temporal_aurora_username" {
+  secret_id     = aws_secretsmanager_secret.temporal_aurora_username.id
+  secret_string = var.temporal_aurora_username
+}

--- a/modules/aws_ecs_ec2/temporal/variables.tf
+++ b/modules/aws_ecs_ec2/temporal/variables.tf
@@ -1,0 +1,166 @@
+# namescape: temporal namespace to use for Retool Workflows. We recommend this is only used by Retool.
+# host: hostname for Temporal Frontend service
+# port: port for Temporal Frontend service
+# tls_enabled: Whether to use tls when connecting to Temporal Frontend. For mTLS, configure tls_crt and tls_key.
+# tls_crt: For mTLS only. Base64 encoded string of public tls certificate
+# tls_key: For mTLS only. Base64 encoded string of private tls key
+variable "temporal_cluster_config" {
+  type = object({
+      namespace   = string
+      host        = string
+      port        = string
+      tls_enabled = bool
+      tls_crt     = optional(string)
+      tls_key     = optional(string)
+    })
+
+    default = {
+      namespace   = "workflows"
+      host        = "temporal.retoolsvc"
+      port        = "7233"
+      tls_enabled = false
+    }
+}
+
+variable "temporal_services_config" {
+  type = map(object({
+      request_port = number
+      membership_port = number
+      cpu = number
+      memory = number
+  }))
+
+  default = {
+    frontend: {
+      request_port = 7233,
+      membership_port = 6933
+      cpu = 512
+      memory = 1024
+    },
+    history: {
+      request_port = 7234,
+      membership_port = 6934
+      cpu = 512
+      memory = 2048
+    },
+    matching: {
+      request_port = 7235,
+      membership_port = 6935
+      cpu = 512
+      memory = 1024
+    },
+    worker: {
+      request_port = 7239,
+      membership_port = 6939
+      cpu = 512
+      memory = 1024
+    }
+  }
+}
+
+variable "deployment_name" {
+    type      = string
+    default   = "retool-temporal"
+    description = "Name for Temporal Cluster deployment. Defaults to retool-temporal"
+}
+
+variable "launch_type" {
+  type        = string
+  default     = "FARGATE"
+
+  validation {
+    condition = contains(["FARGATE", "EC2"], var.launch_type)
+    error_message = "launch_type must be either \"FARGATE\" or \"EC2\""
+  }
+}
+
+variable "temporal_aurora_username" {
+  type        = string
+  default     = "retool"
+  description = "Master username for the Temporal Aurora instance. Defaults to retool."
+}
+
+variable "temporal_aurora_publicly_accessible" {
+  type        = bool
+  default     = false
+  description = "Whether the Temporal Aurora instance should be publicly accessible. Defaults to false."
+}
+
+variable "temporal_aurora_performance_insights_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether to enable Performance Insights for Temporal Aurora. Defaults to true."
+}
+
+variable "temporal_aurora_performance_insights_retention_period" {
+  type        = number
+  default     = 14
+  description = "The time in days to retain Performance Insights for Temporal Aurora. Defaults to 14."
+}
+
+variable "additional_temporal_env_vars" {
+  type        = list(map(string))
+  default     = []
+  description = "Additional environment variables for Temporal containers (e.g. DYNAMIC_CONFIG_PATH)"
+}
+
+variable "private_dns_namespace_id" {
+  type        = string
+  description = "ID for private DNS namespace to use for Temporal Frontend service"
+}
+
+variable "temporal_image" {
+  type = string
+  default = "tryretool/one-offs:retool-temporal-1.1.2"
+  description = "Docker image to use for Temporal cluster."
+}
+
+variable "secret_length" {
+  type        = number
+  default     = 48
+  description = "Length of secrets generated (e.g. ENCRYPTION_KEY, RDS_PASSWORD). Defaults to 48."
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "Select a VPC that allows instances access to the Internet."
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Select at two subnets in your selected VPC."
+}
+
+variable "container_sg_id" {
+  type = string
+  description = "ID for security group to use for ECS service"
+}
+
+variable "aws_ecs_capacity_provider_name" {
+  type = string
+  description = "Name for ECS capacity provider for EC2"
+}
+
+variable "additional_env_vars" {
+  type        = list(map(string))
+  default     = []
+  description = "Additional environment variables (e.g. BASE_DOMAIN)"
+}
+
+variable "aws_ecs_cluster_id" {
+  type = string
+  description = "ID for ECS cluster to deploy Temporal to."
+}
+
+variable "aws_cloudwatch_log_group_id" {
+  type        = string
+  description = "ID for AWS CloudWatch log group"
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "AWS region. Defaults to `us-east-1`"
+}
+
+


### PR DESCRIPTION
Manually went through diffs of the existing `aws_ecs_ec2` module currently in use with the new `aws_ecs` module and copied over required changes and additions such as `workflows` and `temporal` setup.

Also moved out cluster config to `ecs.ts` file to match `aws_ecs` structure

In hindsight it would have been easier to copy our changes to `aws_ecs` and use that, which now also supports Fargate as a configuration, but we can do that later if needed.